### PR TITLE
Remove from_repr for loop and Clone requirement

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@
 //!
 //! use libc::*;
 //!
-//! #[derive(Clone, Debug, PartialEq)]
+//! #[derive(Debug, PartialEq)]
 //! #[derive(EnumRepr)]
 //! #[EnumReprType = "c_int"]
 //! pub enum IpProto {
@@ -43,7 +43,7 @@
 //! #
 //! # use libc::*;
 //! #
-//! # #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+//! # #[derive(Debug, Eq, Hash, PartialEq)]
 //! #[derive(EnumRepr)]
 //! #[EnumReprType = "c_int"]
 //! pub enum InetDomain {
@@ -51,7 +51,7 @@
 //!     // …
 //! }
 //!
-//! # #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+//! # #[derive(Debug, Eq, Hash, PartialEq)]
 //! #[derive(EnumRepr)]
 //! #[EnumReprType = "c_int"]
 //! pub enum SocketType {
@@ -75,7 +75,7 @@
 //! ```
 //! # #[macro_use] extern crate enum_repr;
 //! #
-//! #[derive(Clone, PartialEq)]
+//! #[derive(PartialEq)]
 //! #[derive(EnumRepr)]
 //! #[EnumReprType = "u16"]
 //! enum En {
@@ -92,7 +92,7 @@
 //!
 //! # #[macro_use] extern crate enum_repr;
 //! #
-//! #[derive(Clone, PartialEq)]
+//! #[derive(PartialEq)]
 //! #[derive(EnumRepr)]
 //! #[EnumReprType = "u16"]
 //! enum En {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,10 +148,6 @@ pub fn enum_repr(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 
     let gen = quote! {
         impl #impl_generics #ty #ty_generics #where_clause {
-            const VAR_TO_DISCR: [(#repr_ty, #ty); #vars_len] = [
-                #( (#discrs as #repr_ty_repeat2, #ty_repeat :: #names) ),*
-            ];
-
             #vis fn repr(&self) -> #repr_ty2 {
                 use #ty::*;
                 match self {
@@ -160,12 +156,10 @@ pub fn enum_repr(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
             }
 
             #vis fn from_repr(x: #repr_ty3) -> Option<#ty> {
-                for (v,d) in &Self::VAR_TO_DISCR {
-                    if x == *v {
-                        return Some((*d).clone());
-                    }
+                match x {
+                    #( x if x == #discrs as #repr_ty_repeat2 => Some(#ty_repeat :: #names),)*
+                    _ => None,
                 }
-                None
             }
         }
     };


### PR DESCRIPTION
I played around with the macro implementation. For an optimized release build I guess the performance is basically identical. But I thought this version I came up with was a bit simpler. Both to read the macro itself, and also the expanded code if one inspects that.

This also gets rid of the requirement that the enum in question must implement `Clone`. Now it does not have to any longer.

After this change, this code:
```rust
#[derive(EnumRepr)]
#[EnumReprType = "u16"]
pub enum Test {
    A = 1,
    B = 2,
    C = 3,
}
```
Expands to this `from_repr` code:
```rust
pub fn from_repr(x: u16) -> Option<Test> {
    match x {
        x if x == 1 as u16 => Some(Test::A),
        x if x == 2 as u16 => Some(Test::B),
        x if x == 3 as u16 => Some(Test::C),
        _ => None,
    }
}
```